### PR TITLE
Wait for recent media query to complete before firing another

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -17,6 +17,7 @@ let apiTokens = {
 };
 
 let minTagId;
+let busy = false;
 
 const wrapper = {
   setClientId() {
@@ -69,9 +70,16 @@ const wrapper = {
   },
 
   getRecentMedia(next) {
+    if (busy) {
+      return next();
+    }
+
+    busy = true;
+
     this.setUserToken();
     api.tag_media_recent(tag, { min_tag_id: minTagId }, (err, medias, pagination, remaining) => {
       minTagId = pagination.min_tag_id;
+      busy = false;
 
       if (err) {
         return next(err);

--- a/lib/services.js
+++ b/lib/services.js
@@ -97,7 +97,7 @@ const services = {
             } else {
               console.log(err);
             }
-          } else {
+          } else if (medias) {
             instagram.emitImageMedia(medias, io);
 
             console.log('remaining: ' + remaining);


### PR DESCRIPTION
This should fix the random appearances of duplicate images.
