### PR TITLE
Check if pagination object exists upon API response

### DIFF
--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -78,12 +78,18 @@ const wrapper = {
 
     this.setUserToken();
     api.tag_media_recent(tag, { min_tag_id: minTagId }, (err, medias, pagination, remaining) => {
-      minTagId = pagination.min_tag_id;
       busy = false;
 
       if (err) {
         return next(err);
       }
+
+      // Instagram pagination obj is inconsistent
+      if (!pagination) {
+        return next();
+      }
+
+      minTagId = pagination.min_tag_id;
 
       return next(null, medias, remaining);
     });


### PR DESCRIPTION
Instagram's API seems to be inconsistent with it's pagination object.
